### PR TITLE
Allow to overwrite template settings in entity config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "room-card",
-  "version": "1.08.03",
+  "version": "1.08.04",
   "description": "Show entities in Home Assistant's Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/template.ts
+++ b/src/template.ts
@@ -15,7 +15,7 @@ export const mapTemplate = (entity: RoomCardEntity, config: RoomCardConfig) => {
         if(templatesWithMatchingName.length > 0) {
             const templateFromConfig = templatesWithMatchingName[0];
 
-            return { stateObj: entity.stateObj, ...entity, ...templateFromConfig.template };
+            return { stateObj: entity.stateObj, ...templateFromConfig.template, ...entity };
         }
     }
 


### PR DESCRIPTION
This is fixing entity templates behaviour, where settings defined in a template couldn't be changed later in an entity using that template.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your contribution.
-->

- [x] Version is upped
- [] Info.md is up to date
- [] Unit tests coverage is 100 %
